### PR TITLE
Remove unecessary macro-id in syntax related to Confluence TOC.

### DIFF
--- a/Cask
+++ b/Cask
@@ -4,4 +4,5 @@
 (package-file "ox-cs.el")
 
 (development
-  (depends-on "package-lint"))
+ (depends-on "package-lint")
+ (depends-on "elisp-lint"))

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,9 @@ lint:
 	@echo "Linting the package..."
 	cask emacs -Q -batch -l package-lint.el \
 	-f package-lint-batch-and-exit ox-cs.el
+	cask emacs -Q --batch -l elisp-lint.el -f \
+	elisp-lint-files-batch *.el
+
+clean:
+	@echo "Removing the byte compiled file ..."
+	rm org-export-confluence-autoloads.el

--- a/ox-cs.el
+++ b/ox-cs.el
@@ -1,6 +1,6 @@
 ;;; ox-cs.el --- Export org-mode files to confluence storage
-     
-;; Copyright (C) 2020 
+
+;; Copyright (C) 2020
 
 ;; Author: Andre Toledo <aandreetoledo@gmail.com>
 ;; Maintainer: Inaqui Medina <inaqui.medina@gmail.com>
@@ -15,26 +15,53 @@
 ;; This package tailors org-mode export to html to match the syntax of
 ;; confluence storage.
 
+;;; Code:
+
+(require 'ox)
 (require 'org)
 (provide 'ox-cs)
 
 (setq org-html-head-include-default-style nil)
 (setq org-html-table-default-attributes nil)
 
-(org-export-define-derived-backend 'confluence-storage 'html
-				   :menu-entry '(?C "Confluence Storage" ox-cs)
-				   :translate-alist '((template . ox-cs-template)
-						      (inner-template . ox-cs-inner-template)))
 
+(org-export-define-derived-backend 'confluence-storage 'html
+  :menu-entry '(?C "Confluence Storage" ox-cs)
+  :translate-alist '((template . ex-cs-template)
+		     (innter-template . ox-cs-inner-template)))
 
 ;;;###autoload
 (defun ox-cs
-(&optional async subtreep visible-only body-only ext-plist)
+    (&optional async subtreep visible-only body-only ext-plist)
+  "This is te entry point to the program.
+ASYNC
+SUBTREEP
+VISIBLE-ONLY
+BODY-ONLY
+EXT-PLIST"
   (interactive)
-  (org-export-to-buffer 'confluence-storage "*Org Confluence Storage Export*"
-    async subtreep visible-only body-only ext-plist (lambda () (html-mode))))   
+  (org-export-to-buffer
+      'confluence-storage
+      "*Org Confluence Storage Export*"
+    async
+    subtreep
+    visible-only
+    body-only
+    ext-plist (lambda () (html-mode))))
 
-(defun ox-cs-template (contents info) contents)
-(defun ox-cs-inner-template (contents info) (concat "<ac:structured-macro ac:macro-id=\"954618d1-3832-4140-a7c1-e0120ef6d3dc\" ac:name=\"toc\" ac:schema-version=\"1\"/>\n\n" contents))
+(defun ox-cs-template (contents info)
+  "Simplify template eliminating unecessary elements.
+Arguments:
+CONTENTS
+INFO"
+  contents)
+
+(defun ox-cs-inner-template (contents info)
+  "Implement Confluence Table of Contents.
+Arguments:
+CONTENTS
+INFO"
+  (concat "<ac:structured-macro ac:name=\"toc\" \
+ ac:schema-version=\"1\"/>\n\n" contents))
 
 ;;; ox-cs.el ends here


### PR DESCRIPTION
The macro utilized in order to implement Confluence's Table of
Contents had a specific id, that is automatically added by the
platform. It is not necessary to include the id in the package
so it was removed.

Other changes were applied with additional linting implemented
in the checking and makefile. See elisp-lint for addiitional details.